### PR TITLE
FSA2021-118 - make grid responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <title>Color Grid Game</title>
 </head>
 <body>
+  <main>
   <form id="color-form">
     <div class="form-top-row">
       <input type="color" id="top-left" name="top-left" value="#ff0000">
@@ -31,6 +32,7 @@
     <input type="reset" value="reset form">
     </form>
     <div id="grid-container"></div>
+  </main>
   <script src="./src/index.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,12 +4,15 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./src/sass/main.scss">
+  
   <title>Color Grid Game</title>
 </head>
 <body>
   <main>
-  <form id="color-form">
+  <form class="color-form">
     <div class="form-top-row">
       <input type="color" id="top-left" name="top-left" value="#ff0000">
       <label for="top-left">Pick top left color</label>
@@ -31,7 +34,7 @@
     <input type="submit" value="get colors">
     <input type="reset" value="reset form">
     </form>
-    <div id="grid-container"></div>
+    <div class="grid-container"></div>
   </main>
   <script src="./src/index.js"></script>
 </body>

--- a/src/color-utils/index.js
+++ b/src/color-utils/index.js
@@ -5,17 +5,6 @@ const checkRGBValidity = (num) => {
   return (num >= 0 && num <= 255);
 };
 
-const componentToHex = (rgbVal) => {
-  if (typeof rgbVal !== 'number') {
-    throw new TypeError('rgbVal must be a number');
-  }
-  if (rgbVal < 0 || rgbVal > 255 || !Number.isInteger(rgbVal)) {
-    throw new Error('rgbVal must be an integer between 0 and 255, inclusive');
-  }
-  const hex = rgbVal.toString(16);
-  return hex.length === 1 ? `0${hex}` : hex;
-};
-
 const convertRGBToHex = (r, g, b) => `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
 
 const convertHexToRGB = (hex) => {
@@ -28,6 +17,23 @@ const convertHexToRGB = (hex) => {
     g: parseInt(result[2], 16),
     b: parseInt(result[3], 16),
   } : null;
+}
+
+// RELOCATE
+const isInteger = (value) => typeof value === 'number'
+    // eslint-disable-next-line no-restricted-globals
+    && isFinite(value)
+    && Math.floor(value) === value;
+
+const componentToHex = (rgbVal) => {
+  if (typeof rgbVal !== 'number') { 
+    throw new TypeError('rgbVal must be a number');
+  }
+  if (rgbVal < 0 || rgbVal > 255 || !isInteger(rgbVal)) {
+    throw new Error('rgbVal must be an integer between 0 and 255, inclusive');
+  }
+  const hex = rgbVal.toString(16);
+  return hex.length === 1 ? `0${hex}` : hex;
 };
 
 module.exports = {
@@ -35,4 +41,5 @@ module.exports = {
   convertRGBToHex,
   convertHexToRGB,
   componentToHex,
-};
+  isInteger
+}

--- a/src/grid/stops.js
+++ b/src/grid/stops.js
@@ -1,4 +1,4 @@
-const { checkRGBValidity } = require('../color-utils');
+const { checkRGBValidity, isInteger } = require('../color-utils');
 
 const makeStops = (size, startVal, endVal) => {
   if (typeof size !== 'number') {
@@ -7,15 +7,15 @@ const makeStops = (size, startVal, endVal) => {
   if (size < 2) {
     throw new Error('size must be at least 2');
   }
-  if (!Number.isInteger(size)) {
+  if (!isInteger(size)) {
     throw new Error('size must be an integer');
   }
   // confirm that we're given a valid integer between 0 and 255, inclusive
   if (
     !checkRGBValidity(startVal)
     || !checkRGBValidity(endVal)
-    || !Number.isInteger(startVal)
-    || !Number.isInteger(endVal)
+    || !isInteger(startVal)
+    || !isInteger(endVal)
   ) {
     throw new Error('not a valid startVal or endVal');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,10 @@ function clearGridContainer() {
 }
 
 function fillColors(grid) {
+
   const container = document.getElementById('grid-container');
+  // sets the variable
+  container.style.setProperty('--size', grid.length);
   grid.forEach((row) => {
     const newRowDiv = document.createElement('div');
     newRowDiv.classList.add('color-row');

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,12 @@
 const { makeGrid } = require('./grid/grid');
 
 function clearGridContainer() {
-  const container = document.getElementById('grid-container');
+  const container = document.getElementsByClassName('grid-container')[0];
   container.innerHTML = '';
 }
 
 function fillColors(grid) {
-
-  const container = document.getElementById('grid-container');
+  const container = document.getElementsByClassName('grid-container')[0];
   // sets the variable
   container.style.setProperty('--size', grid.length);
   grid.forEach((row) => {
@@ -32,7 +31,7 @@ function handleSubmit(event) {
   fillColors(colorGrid);
 }
 
-const form = document.getElementById('color-form');
+const form = document.getElementsByClassName('color-form')[0];
 form.addEventListener('submit', handleSubmit);
 
 // probably some better validation for the hex values on this side of things would be nice too

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap');
-
 body {
   height: 100vh;
   margin: 0;
   font-family: 'Roboto', sans-serif;
+  font-weight: 300;
 }
 
 main {
@@ -12,7 +11,7 @@ main {
   justify-content: center;
 }
 
-#color-form {
+.color-form {
   margin-bottom: 2rem;
   min-width: 95vw;
   margin: 2rem auto;
@@ -20,7 +19,7 @@ main {
   // if we do want to "center" the form, can add the media queries from below here
 }
 
-#grid-container {
+.grid-container {
   --width: 95vw;
   --grid: calc(var(--width) / var(--size));
   text-align: center;

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -6,78 +6,58 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+main {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+#color-form {
+  margin-bottom: 2rem;
+  min-width: 95vw;
+  margin: 2rem auto;
+
+  // if we do want to "center" the form, can add the media queries from below here
+}
+
 #grid-container {
   --width: 95vw;
   --grid: calc(var(--width) / var(--size));
   text-align: center;
+  padding-bottom: 2rem;
 
   @media (min-width: 50rem) {
     --width: 80vw;
   }
   
-  // overrides the screen-width media query above
-  @media (orientation: landscape) {
-    --width: 50vw;
-  }
-  
-  // overrides the orientation media query above
   @media (min-width: 100rem) {
     --width: 40vw;
+  }
+
+  // if orientation is landscape, grid size is based on viewport height rather than width
+  @media (orientation: landscape) {
+    --width: 75vh;
   }
 }
 
 .color-row {
-  height: var(--grid);
+  // default height for browsers that don't understand css variables
+  height: 60px;
   width: 100vw;
+
+  @supports (--css: variables) {
+    height: var(--grid);
+  }
 }
 
 .color-tile {
-  height: var(--grid);
-  width: var(--grid);
+  // default height/width for browsers that don't understand css variables
+  height: 60px;
+  width: 60px;
   display: inline-block;
+
+  @supports (--css: variables) {
+    height: var(--grid);
+    width: var(--grid);
+  }
 }
-
-// @media (min-width: 50rem) {
-//   #grid-container {
-//     --width: 80vw;
-//   }
-// }
-
-// // overrides the screen-width media query above
-// @media (orientation: landscape) {
-//   #grid-container {
-//     --width: 50vw;
-//   }
-// }
-
-// // overrides the orientation media query above
-// @media (min-width: 100rem) {
-//   #grid-container {
-//     --width: 40vw;
-//   }  
-// }
-
-
-// // would prefer to use these than having all the things in index.js
-// $body-margin: 8px;
-// $grid-size: 8;
-
-// #color-form {
-//   font-family: 'Roboto', sans-serif;
-//   font-weight: 300;
-// }
-
-// .color-row {
-//   // height: 50px;
-//   line-height: 0;
-//   display: flex;
-//   justify-content: center;
-// }
-
-// .color-tile {
-//   // height: inherit;
-//   min-height: 15px;
-//   min-width: 15px;
-//   // width: calc((100vw - 2 * #{$body-margin}) / #{$grid-size});
-//   display: inline-block;
-// }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -1,15 +1,83 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap');
 
-#color-form {
+body {
+  height: 100vh;
+  margin: 0;
   font-family: 'Roboto', sans-serif;
 }
 
+#grid-container {
+  --width: 95vw;
+  --grid: calc(var(--width) / var(--size));
+  text-align: center;
+
+  @media (min-width: 50rem) {
+    --width: 80vw;
+  }
+  
+  // overrides the screen-width media query above
+  @media (orientation: landscape) {
+    --width: 50vw;
+  }
+  
+  // overrides the orientation media query above
+  @media (min-width: 100rem) {
+    --width: 40vw;
+  }
+}
+
 .color-row {
-  height: 50px;
+  height: var(--grid);
+  width: 100vw;
 }
 
 .color-tile {
-  height: inherit;
-  width: 50px;
+  height: var(--grid);
+  width: var(--grid);
   display: inline-block;
 }
+
+// @media (min-width: 50rem) {
+//   #grid-container {
+//     --width: 80vw;
+//   }
+// }
+
+// // overrides the screen-width media query above
+// @media (orientation: landscape) {
+//   #grid-container {
+//     --width: 50vw;
+//   }
+// }
+
+// // overrides the orientation media query above
+// @media (min-width: 100rem) {
+//   #grid-container {
+//     --width: 40vw;
+//   }  
+// }
+
+
+// // would prefer to use these than having all the things in index.js
+// $body-margin: 8px;
+// $grid-size: 8;
+
+// #color-form {
+//   font-family: 'Roboto', sans-serif;
+//   font-weight: 300;
+// }
+
+// .color-row {
+//   // height: 50px;
+//   line-height: 0;
+//   display: flex;
+//   justify-content: center;
+// }
+
+// .color-tile {
+//   // height: inherit;
+//   min-height: 15px;
+//   min-width: 15px;
+//   // width: calc((100vw - 2 * #{$body-margin}) / #{$grid-size});
+//   display: inline-block;
+// }


### PR DESCRIPTION
# Description

This PR allows the color grid to be rendered no matter the grid size (from 2x2 to 20x20), in any screen size, without breaking.

## Spec
See [FSA-2021-118](https://sparkbox.atlassian.net/browse/FSA2021-118)

## To Validate
1. Pull down the branch.
2. Install dependencies (`npm install`) then run `npm start` and navigate to http://localhost:1234 in your browser.
3. Verify that the grid displays nicely (displays as a square grid composed of square tiles) in various screen sizes.
4. Use the form to check out a few different grid sizes (for example, 10, 15, or 18) and verify that the grid still displays nicely as above.
