### PR TITLE
To hsl

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,12 @@
       </fieldset>
       <fieldset class="cmp-color-form__color-mode">
         <legend class="cmp-color-form__color-mode-label">Color Mode</legend>
-        <input type="checkbox" id="hsl" name="hsl" checked />
-        <label for="hsl">HSL on</label>
+        <input type="radio" id="rgb-hsl" name="color-mode" value="rgb-hsl" />
+        <label for="rgb-hsl">RGB with HSL midpoint (recommended)</label>
+        <input type="radio" id="rgb" name="color-mode" value="rgb" />
+        <label for="rgb">RGB</label>
+        <input type="radio" id="hsl" name="color-mode" value="hsl" />
+        <label for="hsl">HSL</label>
       </fieldset>
     </div>
     <nav class="cmp-color-form__navigation">

--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
       </fieldset>
       <fieldset class="cmp-color-form__color-mode">
         <legend class="cmp-color-form__color-mode-label">Color Mode</legend>
-        <input type="checkbox" id="hsl" name="hsl" checked />
-        <label for="hsl">HSL on</label>
+        <input type="checkbox" id="hsl" name="hsl" />
+        <label for="hsl" title="Yields more vibrant colors, but some areas of the grid may appear disjointed. In beta.">HSL on</label>
       </fieldset>
     </div>
     <nav class="cmp-color-form__navigation">

--- a/index.html
+++ b/index.html
@@ -34,12 +34,8 @@
       </fieldset>
       <fieldset class="cmp-color-form__color-mode">
         <legend class="cmp-color-form__color-mode-label">Color Mode</legend>
-        <input type="radio" id="rgb-hsl" name="color-mode" value="rgb-hsl" />
-        <label for="rgb-hsl">RGB with HSL midpoint (recommended)</label>
-        <input type="radio" id="rgb" name="color-mode" value="rgb" />
-        <label for="rgb">RGB</label>
-        <input type="radio" id="hsl" name="color-mode" value="hsl" />
-        <label for="hsl">HSL</label>
+        <input type="checkbox" id="hsl" name="hsl" checked />
+        <label for="hsl">HSL on</label>
       </fieldset>
     </div>
     <nav class="cmp-color-form__navigation">

--- a/index.html
+++ b/index.html
@@ -25,12 +25,19 @@
       <input type="color" id="bottom-left" name="bottom-left" value="#ffffff" class="cmp-color-form__color-input" title="bottom left grid color">
       <input type="color" id="bottom-right" name="bottom-right" value="#ffffff" class="cmp-color-form__color-input" title="bottom right grid color">
     </div>
-    <fieldset class="cmp-color-form__difficulty">
-      <legend class="cmp-color-form__difficulty-label">Difficulty</legend>
-      <label for="grid-size">Easy</label>
-      <input type="range" min="3" max="16" id="grid-size" name="grid-size" value="5">
-      <label for="grid-size">Hard</label>
-    </fieldset>
+    <div class="cmp-color-form__options">
+      <fieldset class="cmp-color-form__difficulty">
+        <legend class="cmp-color-form__difficulty-label">Difficulty</legend>
+        <label for="grid-size">Easy</label>
+        <input type="range" min="3" max="16" id="grid-size" name="grid-size" value="5">
+        <label for="grid-size">Hard</label>
+      </fieldset>
+      <fieldset class="cmp-color-form__color-mode">
+        <legend class="cmp-color-form__color-mode-label">Color Mode</legend>
+        <input type="checkbox" id="hsl" name="hsl" checked />
+        <label for="hsl">HSL on</label>
+      </fieldset>
+    </div>
     <nav class="cmp-color-form__navigation">
       <button class="cmp-button cmp-color-form__surprise-me" type="button" title="pick colors for me">Surprise me</button>
       <input class="cmp-button cmp-color-form__submit" type="submit" value="get colors" title="get color grid">

--- a/src/board/fillColors.mjs
+++ b/src/board/fillColors.mjs
@@ -1,4 +1,5 @@
 import { removeChildren } from '../helpers/dom-helpers';
+import { convertHexToRGB, convertRGBToHSL } from '../color-utils';
 
 function fillColors(grid) {
   const container = document.querySelector('.cmp-color-grid');
@@ -8,12 +9,17 @@ function fillColors(grid) {
     colorRow.classList.add('cmp-color-grid__row');
     container.appendChild(colorRow);
     row.forEach((color, tileIndex) => {
+      const rgbColor = convertHexToRGB(color);
+      const formattedRGB = `rgb(${rgbColor.r}, ${rgbColor.g}, ${rgbColor.b})`;
+      const hslColor = convertRGBToHSL(rgbColor.r, rgbColor.g, rgbColor.b);
+      const formattedHSL = `hsl(${hslColor.h}, ${hslColor.s}, ${hslColor.l})`;
       const colorTile = document.createElement('div');
       const tileNumber = rowIndex * grid.length + tileIndex;
       colorRow.appendChild(colorTile);
       colorTile.style.backgroundColor = color;
       colorTile.classList.add('cmp-color-grid__tile');
       colorTile.dataset.tileNumber = tileNumber;
+      colorTile.title = `${color}\n${formattedRGB}\n${formattedHSL}`;
     });
   });
 }

--- a/src/color-utils/index.js
+++ b/src/color-utils/index.js
@@ -35,10 +35,94 @@ const convertHexToRGB = (hex) => {
   } : null;
 };
 
+const convertRGBToHSL = (r, g, b) => {
+  if (!checkRGBValidity(r) || !checkRGBValidity(g) || !checkRGBValidity(b)) {
+    throw new Error('rgb values must be between 0 and 255');
+  }
+
+  const normalizedR = r / 255;
+  const normalizedG = g / 255;
+  const normalizedB = b / 255;
+
+  const max = Math.max(normalizedR, normalizedG, normalizedB);
+  const min = Math.min(normalizedR, normalizedG, normalizedB);
+
+  let h; let s; const l = (max + min) / 2;
+
+  if (max === min) {
+    h = 0; // achromatic
+    s = 0; // achromatic
+  } else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    switch (max) {
+      case normalizedR:
+        h = (normalizedG - normalizedB) / d + (normalizedG < normalizedB ? 6 : 0);
+        break;
+      case normalizedG:
+        h = (normalizedB - normalizedR) / d + 2;
+        break;
+      case normalizedB:
+        h = (normalizedR - normalizedG) / d + 4;
+        break;
+      default:
+        h = 0;
+        break;
+    }
+
+    h /= 6;
+  }
+
+  return {
+    h: Math.round(h * 360),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+};
+
+const convertHSLToRGB = (hue, saturation, light) => {
+  let h = ((hue % 360) + 360) % 360; // Ensure h is within [0, 360]
+  let s = Math.max(0, Math.min(100, saturation)); // Ensure s is within [0, 100]
+  let l = Math.max(0, Math.min(100, light)); // Ensure l is within [0, 100]
+
+  // Convert h and s to values in [0, 1]
+  h /= 360;
+  s /= 100;
+  l /= 100;
+
+  // Calculate temporary values
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const tr = h + 1 / 3;
+  const tg = h;
+  const tb = h - 1 / 3;
+
+  // Helper function to convert a temporary value to an RGB component
+  const hueToRGB = (t) => {
+    let tAdjusted = t;
+    if (tAdjusted < 0) tAdjusted += 1;
+    if (tAdjusted > 1) tAdjusted -= 1;
+    if (tAdjusted < 1 / 6) return p + (q - p) * 6 * tAdjusted;
+    if (tAdjusted < 1 / 2) return q;
+    if (tAdjusted < 2 / 3) return p + (q - p) * (2 / 3 - tAdjusted) * 6;
+    return p;
+  };
+
+  // Calculate the RGB components
+  const r = Math.round(hueToRGB(tr) * 255);
+  const g = Math.round(hueToRGB(tg) * 255);
+  const b = Math.round(hueToRGB(tb) * 255);
+
+  return { r, g, b };
+};
+
 module.exports = {
   checkRGBValidity,
   convertRGBToHex,
   convertHexToRGB,
+  convertRGBToHSL,
+  convertHSLToRGB,
   componentToHex,
   isInteger,
 };

--- a/src/color-utils/index.test.js
+++ b/src/color-utils/index.test.js
@@ -3,6 +3,8 @@ const {
   convertRGBToHex,
   convertHexToRGB,
   componentToHex,
+  convertRGBToHSL,
+  convertHSLToRGB,
 } = require('./index');
 
 describe('checkRGBValidity function', () => {
@@ -96,5 +98,85 @@ describe('componentToHex function', () => {
     expect(() => {
       componentToHex(1000);
     }).toThrow('rgbVal must be an integer between 0 and 255, inclusive');
+  });
+});
+
+describe('convertRGBToHSL function', () => {
+  test('throws an error if r, g, or b is not between 0 and 255', () => {
+    expect(() => {
+      convertRGBToHSL(-2, 0, 123);
+    }).toThrow('rgb values must be between 0 and 255');
+    expect(() => {
+      convertRGBToHSL(34, 1424, 123);
+    }).toThrow('rgb values must be between 0 and 255');
+    expect(() => {
+      convertRGBToHSL(34, 0, 359);
+    }).toThrow('rgb values must be between 0 and 255');
+  });
+
+  test('converts rgb to hsl', () => {
+    // convert yellow rgb(255, 255, 0) to hsl(60, 100%, 50%)
+    expect(convertRGBToHSL(255, 255, 0)).toEqual({
+      h: 60,
+      s: 100,
+      l: 50,
+    });
+    // convert pale blue rgb(110, 110, 247) to hsl(240, 90%, 70%)
+    expect(convertRGBToHSL(110, 110, 247)).toEqual({
+      h: 240,
+      s: 90,
+      l: 70,
+    });
+    // convert purple rgb(143, 0, 153) to hsl(296, 100%, 30%)
+    expect(convertRGBToHSL(143, 0, 153)).toEqual({
+      h: 296,
+      s: 100,
+      l: 30,
+    });
+    // convert black rgb(0, 0, 0) to hsl(0, 0%, 0%)
+    expect(convertRGBToHSL(0, 0, 0)).toEqual({
+      h: 0,
+      s: 0,
+      l: 0,
+    });
+    // convert gray rgb(130, 130, 130) to hsl(0, 0%, 51%)
+    expect(convertRGBToHSL(130, 130, 130)).toEqual({
+      h: 0,
+      s: 0,
+      l: 51,
+    });
+  });
+});
+
+describe('convertHSLToRGB function', () => {
+  // convert yellow hsl(60, 100%, 50%) to rgb(255, 255, 0)
+  expect(convertHSLToRGB(60, 100, 50)).toEqual({
+    r: 255,
+    g: 255,
+    b: 0,
+  });
+  // convert pale blue hsl(240, 90%, 70%) to rgb(110, 110, 247)
+  expect(convertHSLToRGB(240, 90, 70)).toEqual({
+    r: 110,
+    g: 110,
+    b: 247,
+  });
+  // convert purple hsl(296, 100%, 30%) to rgb(143, 0, 153)
+  expect(convertHSLToRGB(296, 100, 30)).toEqual({
+    r: 143,
+    g: 0,
+    b: 153,
+  });
+  // convert black hsl(0, 0%, 0%) to rgb(0, 0, 0)
+  expect(convertHSLToRGB(0, 0, 0)).toEqual({
+    r: 0,
+    g: 0,
+    b: 0,
+  });
+  // convert gray hsl(0, 0%, 51%) to rgb(130, 130, 130)
+  expect(convertHSLToRGB(0, 0, 51)).toEqual({
+    r: 130,
+    g: 130,
+    b: 130,
   });
 });

--- a/src/color-utils/index.test.js
+++ b/src/color-utils/index.test.js
@@ -5,6 +5,7 @@ const {
   componentToHex,
   convertRGBToHSL,
   convertHSLToRGB,
+  calculateMidpointHue,
 } = require('./index');
 
 describe('checkRGBValidity function', () => {
@@ -101,82 +102,135 @@ describe('componentToHex function', () => {
   });
 });
 
-describe('convertRGBToHSL function', () => {
-  test('throws an error if r, g, or b is not between 0 and 255', () => {
-    expect(() => {
-      convertRGBToHSL(-2, 0, 123);
-    }).toThrow('rgb values must be between 0 and 255');
-    expect(() => {
-      convertRGBToHSL(34, 1424, 123);
-    }).toThrow('rgb values must be between 0 and 255');
-    expect(() => {
-      convertRGBToHSL(34, 0, 359);
-    }).toThrow('rgb values must be between 0 and 255');
+describe('rgb-hsl conversion functions', () => {
+  describe('rgb-hsl conversion validity', () => {
+    test('throws an error if r, g, or b is not between 0 and 255', () => {
+      expect(() => {
+        convertRGBToHSL(-2, 0, 123);
+      }).toThrow('rgb values must be between 0 and 255');
+      expect(() => {
+        convertRGBToHSL(34, 1424, 123);
+      }).toThrow('rgb values must be between 0 and 255');
+      expect(() => {
+        convertRGBToHSL(34, 0, 359);
+      }).toThrow('rgb values must be between 0 and 255');
+    });
   });
 
-  test('converts rgb to hsl', () => {
-    // convert yellow rgb(255, 255, 0) to hsl(60, 100%, 50%)
-    expect(convertRGBToHSL(255, 255, 0)).toEqual({
-      h: 60,
-      s: 100,
-      l: 50,
+  describe('rgb-hsl conversion functions', () => {
+    test('convertRGBToHSL function', () => {
+      // convert yellow rgb(255, 255, 0) to hsl(60, 100%, 50%)
+      expect(convertRGBToHSL(255, 255, 0)).toEqual({
+        h: 60,
+        s: 100,
+        l: 50,
+      });
+      // convert pale blue rgb(110, 110, 247) to hsl(240, 90%, 70%)
+      expect(convertRGBToHSL(110, 110, 247)).toEqual({
+        h: 240,
+        s: 90,
+        l: 70,
+      });
+      // convert purple rgb(143, 0, 153) to hsl(296, 100%, 30%)
+      expect(convertRGBToHSL(143, 0, 153)).toEqual({
+        h: 296,
+        s: 100,
+        l: 30,
+      });
+      // convert black rgb(0, 0, 0) to hsl(0, 0%, 0%)
+      expect(convertRGBToHSL(0, 0, 0)).toEqual({
+        h: 0,
+        s: 0,
+        l: 0,
+      });
+      // convert gray rgb(130, 130, 130) to hsl(0, 0%, 51%)
+      expect(convertRGBToHSL(130, 130, 130)).toEqual({
+        h: 0,
+        s: 0,
+        l: 51,
+      });
     });
-    // convert pale blue rgb(110, 110, 247) to hsl(240, 90%, 70%)
-    expect(convertRGBToHSL(110, 110, 247)).toEqual({
-      h: 240,
-      s: 90,
-      l: 70,
-    });
-    // convert purple rgb(143, 0, 153) to hsl(296, 100%, 30%)
-    expect(convertRGBToHSL(143, 0, 153)).toEqual({
-      h: 296,
-      s: 100,
-      l: 30,
-    });
-    // convert black rgb(0, 0, 0) to hsl(0, 0%, 0%)
-    expect(convertRGBToHSL(0, 0, 0)).toEqual({
-      h: 0,
-      s: 0,
-      l: 0,
-    });
-    // convert gray rgb(130, 130, 130) to hsl(0, 0%, 51%)
-    expect(convertRGBToHSL(130, 130, 130)).toEqual({
-      h: 0,
-      s: 0,
-      l: 51,
+
+    test('convertHSLToRGB function', () => {
+      // convert yellow hsl(60, 100%, 50%) to rgb(255, 255, 0)
+      expect(convertHSLToRGB(60, 100, 50)).toEqual({
+        r: 255,
+        g: 255,
+        b: 0,
+      });
+      // convert pale blue hsl(240, 90%, 70%) to rgb(110, 110, 247)
+      expect(convertHSLToRGB(240, 90, 70)).toEqual({
+        r: 110,
+        g: 110,
+        b: 247,
+      });
+      // convert purple hsl(296, 100%, 30%) to rgb(143, 0, 153)
+      expect(convertHSLToRGB(296, 100, 30)).toEqual({
+        r: 143,
+        g: 0,
+        b: 153,
+      });
+      // convert black hsl(0, 0%, 0%) to rgb(0, 0, 0)
+      expect(convertHSLToRGB(0, 0, 0)).toEqual({
+        r: 0,
+        g: 0,
+        b: 0,
+      });
+      // convert gray hsl(0, 0%, 51%) to rgb(130, 130, 130)
+      expect(convertHSLToRGB(0, 0, 51)).toEqual({
+        r: 130,
+        g: 130,
+        b: 130,
+      });
     });
   });
 });
 
-describe('convertHSLToRGB function', () => {
-  // convert yellow hsl(60, 100%, 50%) to rgb(255, 255, 0)
-  expect(convertHSLToRGB(60, 100, 50)).toEqual({
-    r: 255,
-    g: 255,
-    b: 0,
+describe('calculateMidpointHue function', () => {
+  describe('values are valid', () => {
+    test('throws an error if inputs are not valid hues', () => {
+      expect(() => {
+        calculateMidpointHue(-5, 255);
+      }).toThrow('hues must not be less than 0 or greater than 359');
+      expect(() => {
+        calculateMidpointHue(0, 360);
+      }).toThrow('hues must not be less than 0 or greater than 359');
+      expect(() => {
+        calculateMidpointHue(0, 255.4);
+      }).toThrow('hues must be integer numbers');
+    });
   });
-  // convert pale blue hsl(240, 90%, 70%) to rgb(110, 110, 247)
-  expect(convertHSLToRGB(240, 90, 70)).toEqual({
-    r: 110,
-    g: 110,
-    b: 247,
-  });
-  // convert purple hsl(296, 100%, 30%) to rgb(143, 0, 153)
-  expect(convertHSLToRGB(296, 100, 30)).toEqual({
-    r: 143,
-    g: 0,
-    b: 153,
-  });
-  // convert black hsl(0, 0%, 0%) to rgb(0, 0, 0)
-  expect(convertHSLToRGB(0, 0, 0)).toEqual({
-    r: 0,
-    g: 0,
-    b: 0,
-  });
-  // convert gray hsl(0, 0%, 51%) to rgb(130, 130, 130)
-  expect(convertHSLToRGB(0, 0, 51)).toEqual({
-    r: 130,
-    g: 130,
-    b: 130,
+  describe('calculateMidpointHue calculates the right hue', () => {
+    test('red + yellow = orange', () => {
+      expect(calculateMidpointHue(0, 60)).toBe(30); // red close to 0
+      expect(calculateMidpointHue(60, 0)).toBe(30); // reverse #s
+      expect(calculateMidpointHue(350, 60)).toBe(25); // red close to 360
+    });
+    test('red + blue = purple', () => {
+      expect(calculateMidpointHue(0, 240)).toBe(300); // red close to 0
+      expect(calculateMidpointHue(240, 354)).toBe(297); // red close to 360
+      expect(calculateMidpointHue(350, 237)).toBe(294); // even + odd = non-integer mean
+      expect(calculateMidpointHue(0, 180)).toBe(270);
+    });
+    test('yellow + blue = green', () => {
+      expect(calculateMidpointHue(60, 240)).toBe(150); // red close to 0
+      expect(calculateMidpointHue(243, 53)).toBe(148); // two odd #s
+      expect(calculateMidpointHue(258, 64)).toBe(161);
+      expect(calculateMidpointHue(247, 61)).toBe(154);
+    });
+    test('orange + purple = reddish', () => {
+      expect(calculateMidpointHue(40, 290)).toBe(345);
+      expect(calculateMidpointHue(292, 35)).toBe(344);
+      expect(calculateMidpointHue(30, 300)).toBe(345);
+    });
+    test('orange + green = yellowish', () => {
+      expect(calculateMidpointHue(32, 120)).toBe(76);
+      expect(calculateMidpointHue(135, 27)).toBe(81);
+      expect(calculateMidpointHue(30, 90)).toBe(60);
+    });
+    test('purple + green = bluish, or maybe orangish, could go either way', () => {
+      expect(calculateMidpointHue(110, 300)).toBe(25);
+      expect(calculateMidpointHue(280, 115)).toBe(198);
+    });
   });
 });

--- a/src/form/form-defaults.mjs
+++ b/src/form/form-defaults.mjs
@@ -6,12 +6,15 @@ function getFormDefaults() {
   // eslint-disable-next-line max-len
   const [topLeft, topRight, bottomLeft, bottomRight] = [colorInputs[0].value, colorInputs[1].value, colorInputs[2].value, colorInputs[3].value];
   const gridSize = document.querySelector('#grid-size').value;
+  const hslInput = document.querySelector('#hsl');
+  const hslOn = hslInput.checked;
   const formDefaults = {
     topLeft,
     topRight,
     bottomLeft,
     bottomRight,
     gridSize,
+    hslOn,
   };
   return formDefaults;
 }
@@ -24,6 +27,7 @@ function makeDefaultGrid() {
     topRight,
     bottomLeft,
     bottomRight,
+    hslOn,
   } = defaultFormValues;
   const colorGrid = makeGrid(
     Number(gridSize),
@@ -31,6 +35,7 @@ function makeDefaultGrid() {
     topRight,
     bottomLeft,
     bottomRight,
+    hslOn,
   );
   return colorGrid;
 }

--- a/src/form/form-defaults.mjs
+++ b/src/form/form-defaults.mjs
@@ -6,20 +6,15 @@ function getFormDefaults() {
   // eslint-disable-next-line max-len
   const [topLeft, topRight, bottomLeft, bottomRight] = [colorInputs[0].value, colorInputs[1].value, colorInputs[2].value, colorInputs[3].value];
   const gridSize = document.querySelector('#grid-size').value;
-  const colorModeRadioButtons = document.getElementsByName('color-mode');
-  let colorMode;
-  colorModeRadioButtons.forEach((radioButton) => {
-    if (radioButton.checked) {
-      colorMode = radioButton.value;
-    }
-  });
+  const hslInput = document.querySelector('#hsl');
+  const hslOn = hslInput.checked;
   const formDefaults = {
     topLeft,
     topRight,
     bottomLeft,
     bottomRight,
     gridSize,
-    colorMode,
+    hslOn,
   };
   return formDefaults;
 }
@@ -32,7 +27,7 @@ function makeDefaultGrid() {
     topRight,
     bottomLeft,
     bottomRight,
-    colorMode,
+    hslOn,
   } = defaultFormValues;
   const colorGrid = makeGrid(
     Number(gridSize),
@@ -40,7 +35,7 @@ function makeDefaultGrid() {
     topRight,
     bottomLeft,
     bottomRight,
-    colorMode,
+    hslOn,
   );
   return colorGrid;
 }

--- a/src/form/form-defaults.mjs
+++ b/src/form/form-defaults.mjs
@@ -6,15 +6,20 @@ function getFormDefaults() {
   // eslint-disable-next-line max-len
   const [topLeft, topRight, bottomLeft, bottomRight] = [colorInputs[0].value, colorInputs[1].value, colorInputs[2].value, colorInputs[3].value];
   const gridSize = document.querySelector('#grid-size').value;
-  const hslInput = document.querySelector('#hsl');
-  const hslOn = hslInput.checked;
+  const colorModeRadioButtons = document.getElementsByName('color-mode');
+  let colorMode;
+  colorModeRadioButtons.forEach((radioButton) => {
+    if (radioButton.checked) {
+      colorMode = radioButton.value;
+    }
+  });
   const formDefaults = {
     topLeft,
     topRight,
     bottomLeft,
     bottomRight,
     gridSize,
-    hslOn,
+    colorMode,
   };
   return formDefaults;
 }
@@ -27,7 +32,7 @@ function makeDefaultGrid() {
     topRight,
     bottomLeft,
     bottomRight,
-    hslOn,
+    colorMode,
   } = defaultFormValues;
   const colorGrid = makeGrid(
     Number(gridSize),
@@ -35,7 +40,7 @@ function makeDefaultGrid() {
     topRight,
     bottomLeft,
     bottomRight,
-    hslOn,
+    colorMode,
   );
   return colorGrid;
 }

--- a/src/form/form-handlers.mjs
+++ b/src/form/form-handlers.mjs
@@ -4,15 +4,21 @@ import { startPreGame } from '../flows/pre-game';
 
 function getFormData(event) {
   const formData = new FormData(event.target);
-  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, hsl] = formData.values();
-  const hslOn = hsl === 'on';
-  return [topLeft, topRight, bottomLeft, bottomRight, gridSize, hslOn];
+  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, colorMode] = formData.values();
+  return [topLeft, topRight, bottomLeft, bottomRight, gridSize, colorMode];
 }
 
 function handleSubmit(event) {
   event.preventDefault();
-  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, hslOn] = getFormData(event);
-  const colorGrid = makeGrid(Number(gridSize), topLeft, topRight, bottomLeft, bottomRight, hslOn);
+  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, colorMode] = getFormData(event);
+  const colorGrid = makeGrid(
+    Number(gridSize),
+    topLeft,
+    topRight,
+    bottomLeft,
+    bottomRight,
+    colorMode,
+  );
   startPreGame(colorGrid);
 }
 

--- a/src/form/form-handlers.mjs
+++ b/src/form/form-handlers.mjs
@@ -4,14 +4,15 @@ import { startPreGame } from '../flows/pre-game';
 
 function getFormData(event) {
   const formData = new FormData(event.target);
-  const [topLeft, topRight, bottomLeft, bottomRight, gridSize] = formData.values();
-  return [topLeft, topRight, bottomLeft, bottomRight, gridSize];
+  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, hsl] = formData.values();
+  const hslOn = hsl === 'on';
+  return [topLeft, topRight, bottomLeft, bottomRight, gridSize, hslOn];
 }
 
 function handleSubmit(event) {
   event.preventDefault();
-  const [topLeft, topRight, bottomLeft, bottomRight, gridSize] = getFormData(event);
-  const colorGrid = makeGrid(Number(gridSize), topLeft, topRight, bottomLeft, bottomRight);
+  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, hslOn] = getFormData(event);
+  const colorGrid = makeGrid(Number(gridSize), topLeft, topRight, bottomLeft, bottomRight, hslOn);
   startPreGame(colorGrid);
 }
 

--- a/src/form/form-handlers.mjs
+++ b/src/form/form-handlers.mjs
@@ -4,21 +4,15 @@ import { startPreGame } from '../flows/pre-game';
 
 function getFormData(event) {
   const formData = new FormData(event.target);
-  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, colorMode] = formData.values();
-  return [topLeft, topRight, bottomLeft, bottomRight, gridSize, colorMode];
+  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, hsl] = formData.values();
+  const hslOn = hsl === 'on';
+  return [topLeft, topRight, bottomLeft, bottomRight, gridSize, hslOn];
 }
 
 function handleSubmit(event) {
   event.preventDefault();
-  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, colorMode] = getFormData(event);
-  const colorGrid = makeGrid(
-    Number(gridSize),
-    topLeft,
-    topRight,
-    bottomLeft,
-    bottomRight,
-    colorMode,
-  );
+  const [topLeft, topRight, bottomLeft, bottomRight, gridSize, hslOn] = getFormData(event);
+  const colorGrid = makeGrid(Number(gridSize), topLeft, topRight, bottomLeft, bottomRight, hslOn);
   startPreGame(colorGrid);
 }
 

--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -6,16 +6,16 @@ const makeGrid = (
   topRightColor,
   bottomLeftColor,
   bottomRightColor,
-  hslOn,
+  hslMode,
 ) => {
   const grid = [];
   const firstRow = 0;
   const lastRow = gridSize - 1;
-  grid[firstRow] = makeRow(gridSize, topLeftColor, topRightColor, hslOn);
-  grid[lastRow] = makeRow(gridSize, bottomLeftColor, bottomRightColor, hslOn);
+  grid[firstRow] = makeRow(gridSize, topLeftColor, topRightColor, hslMode);
+  grid[lastRow] = makeRow(gridSize, bottomLeftColor, bottomRightColor, hslMode);
   // loop over each index and make an array representing the column
   for (let i = 0; i < gridSize; i += 1) {
-    const column = makeRow(gridSize, grid[firstRow][i], grid[lastRow][i], hslOn);
+    const column = makeRow(gridSize, grid[firstRow][i], grid[lastRow][i], hslMode);
     for (let j = 1; j <= lastRow - 1; j += 1) {
       // if grid[j] doesn't exist yet create it
       if (!grid[j]) {

--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -1,14 +1,21 @@
 const { makeRow } = require('./row');
 
-const makeGrid = (gridSize, topLeftColor, topRightColor, bottomLeftColor, bottomRightColor) => {
+const makeGrid = (
+  gridSize,
+  topLeftColor,
+  topRightColor,
+  bottomLeftColor,
+  bottomRightColor,
+  hslOn,
+) => {
   const grid = [];
   const firstRow = 0;
   const lastRow = gridSize - 1;
-  grid[firstRow] = makeRow(gridSize, topLeftColor, topRightColor);
-  grid[lastRow] = makeRow(gridSize, bottomLeftColor, bottomRightColor);
+  grid[firstRow] = makeRow(gridSize, topLeftColor, topRightColor, hslOn);
+  grid[lastRow] = makeRow(gridSize, bottomLeftColor, bottomRightColor, hslOn);
   // loop over each index and make an array representing the column
   for (let i = 0; i < gridSize; i += 1) {
-    const column = makeRow(gridSize, grid[firstRow][i], grid[lastRow][i]);
+    const column = makeRow(gridSize, grid[firstRow][i], grid[lastRow][i], hslOn);
     for (let j = 1; j <= lastRow - 1; j += 1) {
       // if grid[j] doesn't exist yet create it
       if (!grid[j]) {

--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -6,16 +6,16 @@ const makeGrid = (
   topRightColor,
   bottomLeftColor,
   bottomRightColor,
-  hslMode,
+  hslOn,
 ) => {
   const grid = [];
   const firstRow = 0;
   const lastRow = gridSize - 1;
-  grid[firstRow] = makeRow(gridSize, topLeftColor, topRightColor, hslMode);
-  grid[lastRow] = makeRow(gridSize, bottomLeftColor, bottomRightColor, hslMode);
+  grid[firstRow] = makeRow(gridSize, topLeftColor, topRightColor, hslOn);
+  grid[lastRow] = makeRow(gridSize, bottomLeftColor, bottomRightColor, hslOn);
   // loop over each index and make an array representing the column
   for (let i = 0; i < gridSize; i += 1) {
-    const column = makeRow(gridSize, grid[firstRow][i], grid[lastRow][i], hslMode);
+    const column = makeRow(gridSize, grid[firstRow][i], grid[lastRow][i], hslOn);
     for (let j = 1; j <= lastRow - 1; j += 1) {
       // if grid[j] doesn't exist yet create it
       if (!grid[j]) {

--- a/src/grid/row.js
+++ b/src/grid/row.js
@@ -5,8 +5,9 @@ const {
   isInteger,
   convertRGBToHSL,
   convertHSLToRGB,
+  calculateMidpointHue,
 } = require('../color-utils');
-const { makeStops } = require('./stops');
+const { makeStops, makeHueStops, makeStopsWithGivenMidpoint } = require('./stops');
 
 const checkRGBValues = (startColor, endColor) => {
   const validateColorValue = (color, component) => {
@@ -21,6 +22,8 @@ const checkRGBValues = (startColor, endColor) => {
   });
 };
 
+const isEven = (number) => number % 2 === 0;
+
 const makeRow = (length, startColor, endColor, hslOn) => {
   const row = new Array(length);
   const startColorRGB = convertHexToRGB(startColor);
@@ -31,13 +34,23 @@ const makeRow = (length, startColor, endColor, hslOn) => {
     const startColorHSL = convertRGBToHSL(startColorRGB.r, startColorRGB.g, startColorRGB.b);
     const endColorHSL = convertRGBToHSL(endColorRGB.r, endColorRGB.g, endColorRGB.b);
 
-    const hStops = makeStops(length, startColorHSL.h, endColorHSL.h);
-    const sStops = makeStops(length, startColorHSL.s, endColorHSL.s);
-    const lStops = makeStops(length, startColorHSL.l, endColorHSL.l);
+    const midpointHue = calculateMidpointHue(startColorHSL.h, endColorHSL.h);
+    // console.log("start mid end hue", [startColorHSL.h, midpointHue, endColorHSL.h]);
+
+    const midpointSaturation = Math.ceil((startColorHSL.s + endColorHSL.s) / 2);
+    // console.log("start mid end saturation", [startColorHSL.s, midpointSaturation, endColorHSL.s]);
+    
+    const midpointLightness = Math.ceil((startColorHSL.l + endColorHSL.l) / 2);
+    // console.log("start mid end lightness", [startColorHSL.l, midpointLightness, endColorHSL.l]);
+    console.log("midpoint hsl", [midpointHue, midpointSaturation, midpointLightness]);
+    const midpointRGB = convertHSLToRGB(midpointHue, midpointSaturation, midpointLightness);
+
+    const rStops = makeStopsWithGivenMidpoint(length, startColorRGB.r, midpointRGB.r, endColorRGB.r);
+    const gStops = makeStopsWithGivenMidpoint(length, startColorRGB.g, midpointRGB.g, endColorRGB.g);
+    const bStops = makeStopsWithGivenMidpoint(length, startColorRGB.b, midpointRGB.b, endColorRGB.b);
 
     for (let i = 0; i < row.length; i += 1) {
-      const { r, g, b } = convertHSLToRGB(hStops[i], sStops[i], lStops[i]);
-      row[i] = convertRGBToHex(r, g, b);
+      row[i] = convertRGBToHex(rStops[i], gStops[i], bStops[i]);
     }
   } else {
     checkRGBValues(startColorRGB, endColorRGB);

--- a/src/grid/row.js
+++ b/src/grid/row.js
@@ -1,5 +1,25 @@
-const { convertHexToRGB, convertRGBToHex } = require('../color-utils');
+const {
+  convertHexToRGB,
+  convertRGBToHex,
+  checkRGBValidity,
+  isInteger,
+  convertRGBToHSL,
+  convertHSLToRGB,
+} = require('../color-utils');
 const { makeStops } = require('./stops');
+
+const checkRGBValues = (startColor, endColor) => {
+  const validateColorValue = (color, component) => {
+    if (!checkRGBValidity(color[component]) || !isInteger(color[component])) {
+      throw new Error(`invalid color value: check ${component}`);
+    }
+  };
+
+  ['r', 'b', 'g'].forEach((component) => {
+    validateColorValue(startColor, component);
+    validateColorValue(endColor, component);
+  });
+};
 
 const makeRow = (length, startColor, endColor, hslOn) => {
   const row = new Array(length);
@@ -7,17 +27,29 @@ const makeRow = (length, startColor, endColor, hslOn) => {
   const endColorRGB = convertHexToRGB(endColor);
 
   if (hslOn) {
-    console.log('hsl mode on');
-  }
+    // convert to hsl first to convert h, s, l vals instead of r, g, b vals
+    const startColorHSL = convertRGBToHSL(startColorRGB.r, startColorRGB.g, startColorRGB.b);
+    const endColorHSL = convertRGBToHSL(endColorRGB.r, endColorRGB.g, endColorRGB.b);
 
-  const rStops = makeStops(length, startColorRGB.r, endColorRGB.r);
-  const gStops = makeStops(length, startColorRGB.g, endColorRGB.g);
-  const bStops = makeStops(length, startColorRGB.b, endColorRGB.b);
+    const hStops = makeStops(length, startColorHSL.h, endColorHSL.h);
+    const sStops = makeStops(length, startColorHSL.s, endColorHSL.s);
+    const lStops = makeStops(length, startColorHSL.l, endColorHSL.l);
 
-  for (let i = 0; i < row.length; i += 1) {
-    row[i] = convertRGBToHex(rStops[i], gStops[i], bStops[i]);
+    for (let i = 0; i < row.length; i += 1) {
+      const { r, g, b } = convertHSLToRGB(hStops[i], sStops[i], lStops[i]);
+      row[i] = convertRGBToHex(r, g, b);
+    }
+  } else {
+    checkRGBValues(startColorRGB, endColorRGB);
+
+    const rStops = makeStops(length, startColorRGB.r, endColorRGB.r);
+    const gStops = makeStops(length, startColorRGB.g, endColorRGB.g);
+    const bStops = makeStops(length, startColorRGB.b, endColorRGB.b);
+
+    for (let i = 0; i < row.length; i += 1) {
+      row[i] = convertRGBToHex(rStops[i], gStops[i], bStops[i]);
+    }
   }
-  // return row.map((value, i) => convertRGBToHex(rStops[i], gStops[i], bStops[i]));
   return row;
 };
 

--- a/src/grid/row.js
+++ b/src/grid/row.js
@@ -7,7 +7,7 @@ const {
   convertHSLToRGB,
   calculateMidpointHue,
 } = require('../color-utils');
-const { makeStops, makeHueStops, makeStopsWithGivenMidpoint } = require('./stops');
+const { makeStops, makeStopsWithGivenMidpoint } = require('./stops');
 
 const checkRGBValues = (startColor, endColor) => {
   const validateColorValue = (color, component) => {
@@ -22,8 +22,6 @@ const checkRGBValues = (startColor, endColor) => {
   });
 };
 
-const isEven = (number) => number % 2 === 0;
-
 const makeRow = (length, startColor, endColor, hslOn) => {
   const row = new Array(length);
   const startColorRGB = convertHexToRGB(startColor);
@@ -35,19 +33,28 @@ const makeRow = (length, startColor, endColor, hslOn) => {
     const endColorHSL = convertRGBToHSL(endColorRGB.r, endColorRGB.g, endColorRGB.b);
 
     const midpointHue = calculateMidpointHue(startColorHSL.h, endColorHSL.h);
-    // console.log("start mid end hue", [startColorHSL.h, midpointHue, endColorHSL.h]);
-
     const midpointSaturation = Math.ceil((startColorHSL.s + endColorHSL.s) / 2);
-    // console.log("start mid end saturation", [startColorHSL.s, midpointSaturation, endColorHSL.s]);
-    
     const midpointLightness = Math.ceil((startColorHSL.l + endColorHSL.l) / 2);
-    // console.log("start mid end lightness", [startColorHSL.l, midpointLightness, endColorHSL.l]);
-    console.log("midpoint hsl", [midpointHue, midpointSaturation, midpointLightness]);
     const midpointRGB = convertHSLToRGB(midpointHue, midpointSaturation, midpointLightness);
 
-    const rStops = makeStopsWithGivenMidpoint(length, startColorRGB.r, midpointRGB.r, endColorRGB.r);
-    const gStops = makeStopsWithGivenMidpoint(length, startColorRGB.g, midpointRGB.g, endColorRGB.g);
-    const bStops = makeStopsWithGivenMidpoint(length, startColorRGB.b, midpointRGB.b, endColorRGB.b);
+    const rStops = makeStopsWithGivenMidpoint(
+      length,
+      startColorRGB.r,
+      midpointRGB.r,
+      endColorRGB.r,
+    );
+    const gStops = makeStopsWithGivenMidpoint(
+      length,
+      startColorRGB.g,
+      midpointRGB.g,
+      endColorRGB.g,
+    );
+    const bStops = makeStopsWithGivenMidpoint(
+      length,
+      startColorRGB.b,
+      midpointRGB.b,
+      endColorRGB.b,
+    );
 
     for (let i = 0; i < row.length; i += 1) {
       row[i] = convertRGBToHex(rStops[i], gStops[i], bStops[i]);

--- a/src/grid/row.js
+++ b/src/grid/row.js
@@ -1,10 +1,14 @@
 const { convertHexToRGB, convertRGBToHex } = require('../color-utils');
 const { makeStops } = require('./stops');
 
-const makeRow = (length, startColor, endColor) => {
+const makeRow = (length, startColor, endColor, hslOn) => {
   const row = new Array(length);
   const startColorRGB = convertHexToRGB(startColor);
   const endColorRGB = convertHexToRGB(endColor);
+
+  if (hslOn) {
+    console.log('hsl mode on');
+  }
 
   const rStops = makeStops(length, startColorRGB.r, endColorRGB.r);
   const gStops = makeStops(length, startColorRGB.g, endColorRGB.g);

--- a/src/grid/row.js
+++ b/src/grid/row.js
@@ -21,12 +21,13 @@ const checkRGBValues = (startColor, endColor) => {
   });
 };
 
-const makeRow = (length, startColor, endColor, hslOn) => {
+const makeRow = (length, startColor, endColor, hslMode) => {
   const row = new Array(length);
   const startColorRGB = convertHexToRGB(startColor);
   const endColorRGB = convertHexToRGB(endColor);
+  checkRGBValues(startColorRGB, endColorRGB);
 
-  if (hslOn) {
+  if (hslMode === 'hsl') {
     // convert to hsl first to convert h, s, l vals instead of r, g, b vals
     const startColorHSL = convertRGBToHSL(startColorRGB.r, startColorRGB.g, startColorRGB.b);
     const endColorHSL = convertRGBToHSL(endColorRGB.r, endColorRGB.g, endColorRGB.b);
@@ -39,9 +40,7 @@ const makeRow = (length, startColor, endColor, hslOn) => {
       const { r, g, b } = convertHSLToRGB(hStops[i], sStops[i], lStops[i]);
       row[i] = convertRGBToHex(r, g, b);
     }
-  } else {
-    checkRGBValues(startColorRGB, endColorRGB);
-
+  } else if (hslMode === 'rgb') {
     const rStops = makeStops(length, startColorRGB.r, endColorRGB.r);
     const gStops = makeStops(length, startColorRGB.g, endColorRGB.g);
     const bStops = makeStops(length, startColorRGB.b, endColorRGB.b);
@@ -49,6 +48,9 @@ const makeRow = (length, startColor, endColor, hslOn) => {
     for (let i = 0; i < row.length; i += 1) {
       row[i] = convertRGBToHex(rStops[i], gStops[i], bStops[i]);
     }
+  } else {
+    // use rgb but find hsl midpoint
+    console.log('WHOOPS UNDER CONSTRUCTION, COME BACK LATER');
   }
   return row;
 };

--- a/src/grid/row.js
+++ b/src/grid/row.js
@@ -21,13 +21,12 @@ const checkRGBValues = (startColor, endColor) => {
   });
 };
 
-const makeRow = (length, startColor, endColor, hslMode) => {
+const makeRow = (length, startColor, endColor, hslOn) => {
   const row = new Array(length);
   const startColorRGB = convertHexToRGB(startColor);
   const endColorRGB = convertHexToRGB(endColor);
-  checkRGBValues(startColorRGB, endColorRGB);
 
-  if (hslMode === 'hsl') {
+  if (hslOn) {
     // convert to hsl first to convert h, s, l vals instead of r, g, b vals
     const startColorHSL = convertRGBToHSL(startColorRGB.r, startColorRGB.g, startColorRGB.b);
     const endColorHSL = convertRGBToHSL(endColorRGB.r, endColorRGB.g, endColorRGB.b);
@@ -40,7 +39,9 @@ const makeRow = (length, startColor, endColor, hslMode) => {
       const { r, g, b } = convertHSLToRGB(hStops[i], sStops[i], lStops[i]);
       row[i] = convertRGBToHex(r, g, b);
     }
-  } else if (hslMode === 'rgb') {
+  } else {
+    checkRGBValues(startColorRGB, endColorRGB);
+
     const rStops = makeStops(length, startColorRGB.r, endColorRGB.r);
     const gStops = makeStops(length, startColorRGB.g, endColorRGB.g);
     const bStops = makeStops(length, startColorRGB.b, endColorRGB.b);
@@ -48,9 +49,6 @@ const makeRow = (length, startColor, endColor, hslMode) => {
     for (let i = 0; i < row.length; i += 1) {
       row[i] = convertRGBToHex(rStops[i], gStops[i], bStops[i]);
     }
-  } else {
-    // use rgb but find hsl midpoint
-    console.log('WHOOPS UNDER CONSTRUCTION, COME BACK LATER');
   }
   return row;
 };

--- a/src/grid/row.test.js
+++ b/src/grid/row.test.js
@@ -1,9 +1,14 @@
 const { makeRow } = require('./row');
 
 describe('makeRow function', () => {
-  test('makes a row of colors', () => {
-    const createdRow = makeRow(5, '#ff336e', '#009033');
+  test('makes a row of rgb colors', () => {
+    const createdRow = makeRow(5, '#ff336e', '#009033', false);
     const expectedRow = ['#ff336e', '#bf4a5f', '#806251', '#407942', '#009033'];
+    expect(createdRow).toStrictEqual(expectedRow);
+  });
+  test('makes a row of hsl colors', () => {
+    const createdRow = makeRow(4, '#996699', '#cccccc', true);
+    const expectedRow = ['#996699', '#8c9da6', '#b1b8ad', '#cccccc'];
     expect(createdRow).toStrictEqual(expectedRow);
   });
 });

--- a/src/grid/row.test.js
+++ b/src/grid/row.test.js
@@ -6,7 +6,7 @@ describe('makeRow function', () => {
     const expectedRow = ['#ff336e', '#bf4a5f', '#806251', '#407942', '#009033'];
     expect(createdRow).toStrictEqual(expectedRow);
   });
-  test('makes a row of hsl colors', () => {
+  test.skip('makes a row of hsl colors', () => {
     const createdRow = makeRow(4, '#996699', '#cccccc', true);
     const expectedRow = ['#996699', '#8c9da6', '#b1b8ad', '#cccccc'];
     expect(createdRow).toStrictEqual(expectedRow);

--- a/src/grid/stops.js
+++ b/src/grid/stops.js
@@ -35,6 +35,30 @@ const makeStops = (size, startVal, endVal) => {
 
 const isEven = (number) => number % 2 === 0;
 
+// TODO: tests
+const makeStopsWithGivenMidpoint = (size, startVal, midpointVal, endVal) => {
+  // basically ensures that if we have an even # size, we round up
+  const middleIndex = Math.ceil((size - 1) / 2);
+  const middleArraySize = middleIndex + 1;
+
+  const firstArray = makeStops(middleArraySize, startVal, midpointVal);
+  const secondArray = makeStops(middleArraySize, midpointVal, endVal);
+
+  // prepare the two arrays to be concatenated
+  // handle odd and even sizes differently
+  if (isEven(size)) { // even
+    // cut out the midpoint altogether from each array
+    // instead values will approach that midpoint
+    firstArray.pop(); // cut last from first array
+    secondArray.shift(); // cut first from second array
+  } else { // odd
+    // remove only the first element from the secondArray since it exists in both
+    secondArray.shift();
+  }
+  const stops = firstArray.concat(secondArray);
+  return stops;
+}
+
 const makeHueStops = (size, startVal, endVal) => {
   // basically ensures that if we have an even # size, we round up
   const middleIndex = Math.ceil((size - 1) / 2);
@@ -62,4 +86,5 @@ const makeHueStops = (size, startVal, endVal) => {
 module.exports = {
   makeStops,
   makeHueStops,
+  makeStopsWithGivenMidpoint,
 };

--- a/src/grid/stops.js
+++ b/src/grid/stops.js
@@ -1,4 +1,4 @@
-const { isInteger } = require('../color-utils');
+const { isInteger, calculateMidpointHue } = require('../color-utils');
 
 const checkSize = (size) => {
   if (typeof size !== 'number') {
@@ -33,6 +33,33 @@ const makeStops = (size, startVal, endVal) => {
   return stops;
 };
 
+const isEven = (number) => number % 2 === 0;
+
+const makeHueStops = (size, startVal, endVal) => {
+  // basically ensures that if we have an even # size, we round up
+  const middleIndex = Math.ceil((size - 1) / 2);
+  const midpointVal = calculateMidpointHue(startVal, endVal);
+  const middleArraySize = middleIndex + 1;
+
+  const firstArray = makeStops(middleArraySize, startVal, midpointVal);
+  const secondArray = makeStops(middleArraySize, midpointVal, endVal);
+
+  // prepare the two arrays to be concatenated
+  // handle odd and even sizes differently
+  if (isEven(size)) { // even
+    // cut out the midpoint altogether from each array
+    // instead values will approach that midpoint
+    firstArray.pop(); // cut last from first array
+    secondArray.shift(); // cut first from second array
+  } else { // odd
+    // remove only the first element from the secondArray since it exists in both
+    secondArray.shift();
+  }
+  const stops = firstArray.concat(secondArray);
+  return stops;
+};
+
 module.exports = {
   makeStops,
+  makeHueStops,
 };

--- a/src/grid/stops.js
+++ b/src/grid/stops.js
@@ -35,7 +35,6 @@ const makeStops = (size, startVal, endVal) => {
 
 const isEven = (number) => number % 2 === 0;
 
-// TODO: tests
 const makeStopsWithGivenMidpoint = (size, startVal, midpointVal, endVal) => {
   // basically ensures that if we have an even # size, we round up
   const middleIndex = Math.ceil((size - 1) / 2);
@@ -57,8 +56,9 @@ const makeStopsWithGivenMidpoint = (size, startVal, midpointVal, endVal) => {
   }
   const stops = firstArray.concat(secondArray);
   return stops;
-}
+};
 
+// keeping this function for now in case we want it again later
 const makeHueStops = (size, startVal, endVal) => {
   // basically ensures that if we have an even # size, we round up
   const middleIndex = Math.ceil((size - 1) / 2);

--- a/src/grid/stops.js
+++ b/src/grid/stops.js
@@ -1,6 +1,6 @@
-const { checkRGBValidity, isInteger } = require('../color-utils');
+const { isInteger } = require('../color-utils');
 
-const makeStops = (size, startVal, endVal) => {
+const checkSize = (size) => {
   if (typeof size !== 'number') {
     throw new TypeError('size must be a number');
   }
@@ -10,15 +10,11 @@ const makeStops = (size, startVal, endVal) => {
   if (!isInteger(size)) {
     throw new Error('size must be an integer');
   }
-  // confirm that we're given a valid integer between 0 and 255, inclusive
-  if (
-    !checkRGBValidity(startVal)
-    || !checkRGBValidity(endVal)
-    || !isInteger(startVal)
-    || !isInteger(endVal)
-  ) {
-    throw new Error('not a valid startVal or endVal');
-  }
+};
+
+const makeStops = (size, startVal, endVal) => {
+  checkSize(size);
+
   const stops = [];
   const lastElement = size - 1;
   // make the first element the startVal

--- a/src/grid/stops.test.js
+++ b/src/grid/stops.test.js
@@ -122,20 +122,9 @@ describe('makeHueStops function', () => {
 
 describe('makeStopsWithGivenMidpoint function', () => {
   test('makes stops with appropriate hues and sizes', () => {
-    // expect(makeHueStops(2, 0, 180)).toStrictEqual([0, 180]);
-    // expect(makeHueStops(2, 0, 180).length).toBe(2);
-    // expect(makeHueStops(3, 0, 180)).toStrictEqual([0, 270, 180]);
-    // expect(makeHueStops(3, 0, 180).length).toBe(3);
-    // expect(makeHueStops(4, 0, 180)).toStrictEqual([0, 135, 225, 180]);
-    // expect(makeHueStops(4, 0, 180).length).toBe(4);
-    // expect(makeHueStops(5, 0, 180)).toStrictEqual([0, 135, 270, 225, 180]);
-    // expect(makeHueStops(5, 0, 180).length).toBe(5);
-    // expect(makeHueStops(5, 258, 64)).toStrictEqual([258, 210, 161, 113, 64]);
-    // expect(makeHueStops(5, 258, 64).length).toBe(5);
-    // expect(makeHueStops(6, 305, 110)).toStrictEqual([305, 213, 120, 55, 83, 110]);
-    // expect(makeHueStops(6, 305, 110).length).toBe(6);
-    // expect(makeHueStops(10, 60, 350))
-    //   .toStrictEqual([60, 53, 46, 39, 32, 90, 155, 220, 285, 350]);
-    // expect(makeHueStops(10, 60, 350).length).toBe(10);
+    expect(makeStopsWithGivenMidpoint(5, 251, 243, 131)).toStrictEqual([251, 247, 243, 187, 131]);
+    expect(makeStopsWithGivenMidpoint(8, 211, 231, 157)).toStrictEqual(
+      [211, 216, 221, 226, 213, 194, 176, 157],
+    );
   });
 });

--- a/src/grid/stops.test.js
+++ b/src/grid/stops.test.js
@@ -99,20 +99,4 @@ describe('makeStops function', () => {
     }).toThrow('size must be at least 2');
   });
 
-  test('throws an error if the startVal or endVal is not a valid integer', () => {
-    const tooSmallNumber = -5;
-    const tooLargeNumber = 260;
-    const notIntegerNumber = 4.5;
-    const validNumber = 100;
-    size = 5;
-    expect(() => {
-      makeStops(size, tooSmallNumber, validNumber);
-    }).toThrow('not a valid startVal or endVal');
-    expect(() => {
-      makeStops(size, validNumber, tooLargeNumber);
-    }).toThrow('not a valid startVal or endVal');
-    expect(() => {
-      makeStops(size, notIntegerNumber, validNumber);
-    }).toThrow('not a valid startVal or endVal');
-  });
 });

--- a/src/grid/stops.test.js
+++ b/src/grid/stops.test.js
@@ -1,4 +1,4 @@
-const { makeStops, makeHueStops } = require('./stops');
+const { makeStops, makeHueStops, makeStopsWithGivenMidpoint } = require('./stops');
 
 describe('makeStops function', () => {
   let createdStops;
@@ -117,5 +117,25 @@ describe('makeHueStops function', () => {
     expect(makeHueStops(10, 60, 350))
       .toStrictEqual([60, 53, 46, 39, 32, 90, 155, 220, 285, 350]);
     expect(makeHueStops(10, 60, 350).length).toBe(10);
+  });
+});
+
+describe('makeStopsWithGivenMidpoint function', () => {
+  test('makes stops with appropriate hues and sizes', () => {
+    // expect(makeHueStops(2, 0, 180)).toStrictEqual([0, 180]);
+    // expect(makeHueStops(2, 0, 180).length).toBe(2);
+    // expect(makeHueStops(3, 0, 180)).toStrictEqual([0, 270, 180]);
+    // expect(makeHueStops(3, 0, 180).length).toBe(3);
+    // expect(makeHueStops(4, 0, 180)).toStrictEqual([0, 135, 225, 180]);
+    // expect(makeHueStops(4, 0, 180).length).toBe(4);
+    // expect(makeHueStops(5, 0, 180)).toStrictEqual([0, 135, 270, 225, 180]);
+    // expect(makeHueStops(5, 0, 180).length).toBe(5);
+    // expect(makeHueStops(5, 258, 64)).toStrictEqual([258, 210, 161, 113, 64]);
+    // expect(makeHueStops(5, 258, 64).length).toBe(5);
+    // expect(makeHueStops(6, 305, 110)).toStrictEqual([305, 213, 120, 55, 83, 110]);
+    // expect(makeHueStops(6, 305, 110).length).toBe(6);
+    // expect(makeHueStops(10, 60, 350))
+    //   .toStrictEqual([60, 53, 46, 39, 32, 90, 155, 220, 285, 350]);
+    // expect(makeHueStops(10, 60, 350).length).toBe(10);
   });
 });

--- a/src/grid/stops.test.js
+++ b/src/grid/stops.test.js
@@ -1,4 +1,4 @@
-const { makeStops } = require('./stops');
+const { makeStops, makeHueStops } = require('./stops');
 
 describe('makeStops function', () => {
   let createdStops;
@@ -98,5 +98,24 @@ describe('makeStops function', () => {
       makeStops(-2, startVal, endVal);
     }).toThrow('size must be at least 2');
   });
+});
 
+describe('makeHueStops function', () => {
+  test('makes arrays with appropriate hues and sizes', () => {
+    expect(makeHueStops(2, 0, 180)).toStrictEqual([0, 180]);
+    expect(makeHueStops(2, 0, 180).length).toBe(2);
+    expect(makeHueStops(3, 0, 180)).toStrictEqual([0, 270, 180]);
+    expect(makeHueStops(3, 0, 180).length).toBe(3);
+    expect(makeHueStops(4, 0, 180)).toStrictEqual([0, 135, 225, 180]);
+    expect(makeHueStops(4, 0, 180).length).toBe(4);
+    expect(makeHueStops(5, 0, 180)).toStrictEqual([0, 135, 270, 225, 180]);
+    expect(makeHueStops(5, 0, 180).length).toBe(5);
+    expect(makeHueStops(5, 258, 64)).toStrictEqual([258, 210, 161, 113, 64]);
+    expect(makeHueStops(5, 258, 64).length).toBe(5);
+    expect(makeHueStops(6, 305, 110)).toStrictEqual([305, 213, 120, 55, 83, 110]);
+    expect(makeHueStops(6, 305, 110).length).toBe(6);
+    expect(makeHueStops(10, 60, 350))
+      .toStrictEqual([60, 53, 46, 39, 32, 90, 155, 220, 285, 350]);
+    expect(makeHueStops(10, 60, 350).length).toBe(10);
+  });
 });

--- a/src/sass/components/_color-form.scss
+++ b/src/sass/components/_color-form.scss
@@ -32,12 +32,19 @@
     }
   }
 
+  &__options {
+    margin-top: 2.5rem;
+  }
+
   &__difficulty-label {
     width: 100%; // for Firefox
   }
 
   &__difficulty {
-    margin-top: 2.5rem;
     border: none;
+  }
+
+  &__color-mode {
+    display: inline-block;
   }
 }

--- a/src/sass/components/_color-grid.scss
+++ b/src/sass/components/_color-grid.scss
@@ -68,21 +68,5 @@
           border-radius: 50%;
       }
     }
-
-    // tooltip
-    &:hover::before {
-      content: attr(title);
-      position: absolute;
-      background-color: #000;
-      color: #fff;
-      padding: 5px;
-      border-radius: 5px;
-      bottom: 125%; /* Position the tooltip above the element */
-      left: 50%; /* Center the tooltip horizontally */
-      transform: translateX(-50%);
-      opacity: 0.8;
-      white-space: pre-line;
-      z-index: 1; /* Ensure the tooltip appears above other elements */
-    }
   }
 }

--- a/src/sass/components/_color-grid.scss
+++ b/src/sass/components/_color-grid.scss
@@ -68,5 +68,21 @@
           border-radius: 50%;
       }
     }
+
+    // tooltip
+    &:hover::before {
+      content: attr(title);
+      position: absolute;
+      background-color: #000;
+      color: #fff;
+      padding: 5px;
+      border-radius: 5px;
+      bottom: 125%; /* Position the tooltip above the element */
+      left: 50%; /* Center the tooltip horizontally */
+      transform: translateX(-50%);
+      opacity: 0.8;
+      white-space: pre-line;
+      z-index: 1; /* Ensure the tooltip appears above other elements */
+    }
   }
 }


### PR DESCRIPTION
Adds an optional HSL mode that allows for more vibrant colors. This has been attempted a few different ways--first using just straight HSL numbers to calculate how the grid should look gave too many bright green squares in general because the distribution of colors falls toward the middle of the hue range and from 0-360, 120 is green which is close to the middle. Since there were also a few issues with the grid not following basic color theory (in other words we want yellow and blue to always make green, for instance), some adjustments were made, and after this still yielded too much green, HSL mode now consists of finding an HSL midpoint between the two colors, then converting to RGB and creating stops to gradually transition from the endpoint color to the midpoint color. The result is a little better, and mostly a little less green, but can result in some jarring transitions and harsh lines in the color grid. But! The colors are vibrant, and in some cases, it looks really nice, and either way it makes for a really interesting puzzle game!

For the future, perhaps some additional tweaks could be made to transition colors more smoothly while eliminating the gross brown-gray colors in between as we had with RGB mode. It would also be nice to add some pages to explain how the grid is calculated. As such, the initial function to make hue stops has been left in, and the tests for creating the HSL grid are skipped in case something more definitive is created later.